### PR TITLE
Update flutter.yaml

### DIFF
--- a/lib/flutter.yaml
+++ b/lib/flutter.yaml
@@ -2,7 +2,6 @@ include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:
-    implicit-dynamic: false
   errors:
     # Treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/lib/flutter.yaml
+++ b/lib/flutter.yaml
@@ -2,7 +2,6 @@ include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:
-    implicit-casts: false
     implicit-dynamic: false
   errors:
     # Treat missing required parameters as a warning (not a hint)


### PR DESCRIPTION
The option 'implicit-casts' is no longer supported

### What
- Some changes due to flutter 3.10.
- Which somehow prevents us from new PRs in Smoothie.

### Screenshot
![Capture d’écran 2023-05-11 à 12 52 58](https://github.com/openfoodfacts/openfoodfacts_flutter_lints/assets/11576431/654ef3ad-6892-4a6f-9e02-231761e0a170)