### PR TITLE
chore: Fix warnings with Flutter 3.16

### DIFF
--- a/lib/flutter.yaml
+++ b/lib/flutter.yaml
@@ -1,7 +1,6 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
   errors:
     # Treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
@@ -12,10 +11,6 @@ analyzer:
     # Allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
 
 linter:
   rules:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/openfoodfacts/openfoodfacts_flutter_lints/issu
 version: 1.0.0
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Simple fix to allow the upgrade to Flutter 3.16
Here is the current error: https://github.com/openfoodfacts/smooth-app/actions/runs/7411218787/job/20165268562?pr=4917