### PR TITLE
feat: Add `always_put_required_named_parameters_first` rule

### DIFF
--- a/lib/flutter.yaml
+++ b/lib/flutter.yaml
@@ -19,6 +19,7 @@ linter:
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
     always_declare_return_types: true
     always_put_control_body_on_new_line: true
+    always_put_required_named_parameters_first: true
     always_require_non_null_named_parameters: true
     always_specify_types: true
     always_use_package_imports: true


### PR DESCRIPTION
A new rule to ensure that required params are always declared first
https://dart.dev/tools/linter-rules/always_put_required_named_parameters_first